### PR TITLE
fix: enable multi-arch release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Add GOBIN to PATH
         run: echo "${{ github.workspace }}/bin" >> "$GITHUB_PATH"
 
-      - name: Generate protobuf bindings
+      - name: Generate protobuf stubs
         run: |
           buf export buf.build/agynio/api --output internal/.proto
           buf generate internal/.proto --template ./buf.gen.yaml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Set release version
         run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
 
-      - name: Generate protobufs
+      - name: Generate protobuf stubs
         run: |
           buf export buf.build/agynio/api --output internal/.proto
           buf generate internal/.proto --template ./buf.gen.yaml
@@ -71,7 +71,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push release images
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,11 @@ jobs:
         with:
           go-version: '1.22.x'
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/arm64
+
       - uses: docker/setup-buildx-action@v3
 
       - name: Install system dependencies
@@ -70,9 +75,10 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ghcr.io/agynio/token-counting:${{ env.VERSION }}
+            ghcr.io/agynio/token-counting:${{ github.ref_name }}
             ghcr.io/agynio/token-counting:latest
             ghcr.io/agynio/token-counting:${{ github.sha }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,27 +8,12 @@ ARG TARGETARCH
 ENV CGO_ENABLED=0 \
     GOBIN=/usr/local/bin
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates \
-    curl \
-    protobuf-compiler && \
-    rm -rf /var/lib/apt/lists/*
-
-RUN curl -sSL https://github.com/bufbuild/buf/releases/download/v1.64.0/buf-Linux-x86_64.tar.gz \
-      | tar -xzf - -C /usr/local --strip-components=1 buf/bin/buf
-
-RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.34.2 && \
-    go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.5.1
-
 WORKDIR /workspace
 
 COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-
-RUN buf export buf.build/agynio/api --output internal/.proto && \
-    buf generate internal/.proto --template ./buf.gen.yaml
 
 RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     go build -trimpath -ldflags "-s -w" -o /out/token-counting ./cmd/token-counting

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
+# syntax=docker/dockerfile:1.8
+
 FROM golang:1.22 AS builder
 
+ARG TARGETOS
+ARG TARGETARCH
+
 ENV CGO_ENABLED=0 \
-    GOOS=linux \
-    GOARCH=amd64 \
     GOBIN=/usr/local/bin
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -27,7 +30,8 @@ COPY . .
 RUN buf export buf.build/agynio/api --output internal/.proto && \
     buf generate internal/.proto --template ./buf.gen.yaml
 
-RUN go build -o /out/token-counting ./cmd/token-counting
+RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    go build -trimpath -ldflags "-s -w" -o /out/token-counting ./cmd/token-counting
 
 FROM gcr.io/distroless/static-debian12
 


### PR DESCRIPTION
## Summary
- remove protobuf tooling from Dockerfile and rely on workflow-generated stubs
- keep release multi-arch build with QEMU and v-prefixed tags
- bump docker/build-push-action to v6

## Testing
- make proto
- make test
- make lint

Refs #7