### PR TITLE
fix(release): add v-prefixed tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,7 @@ jobs:
           images: ${{ env.IMAGE_NAME }}
           tags: |
             type=sha,format=short,prefix=sha-
+            type=semver,pattern=v{{version}}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}


### PR DESCRIPTION
## Summary
- publish v-prefixed semver tags alongside plain version tags in the release workflow
- align token-counting image tagging with tracing's release pattern

## Testing
- go vet ./...
- go test ./...
- go build ./...

Refs: agynio/token-counting#11