### PR TITLE
fix(chart): add document separators

### DIFF
--- a/charts/token-counting/templates/service-base.yaml
+++ b/charts/token-counting/templates/service-base.yaml
@@ -1,8 +1,15 @@
-{{- include "service-base.rbac" . -}}
-{{- include "service-base.serviceAccount" . -}}
-{{- include "service-base.service" . -}}
-{{- include "service-base.deployment" . -}}
-{{- include "service-base.hpa" . -}}
-{{- include "service-base.ingress" . -}}
-{{- include "service-base.pdb" . -}}
-{{- include "service-base.metrics" . -}}
+{{ include "service-base.rbac" . }}
+---
+{{ include "service-base.serviceAccount" . }}
+---
+{{ include "service-base.service" . }}
+---
+{{ include "service-base.deployment" . }}
+---
+{{ include "service-base.hpa" . }}
+---
+{{ include "service-base.ingress" . }}
+---
+{{ include "service-base.pdb" . }}
+---
+{{ include "service-base.metrics" . }}


### PR DESCRIPTION
## Summary
- add YAML document separators between service-base includes to fix helm template parsing
- align service-base template structure with tracing chart

## Testing
- helm dependency build charts/token-counting
- helm lint charts/token-counting
- go vet ./...
- go test ./...
- go build ./...

Refs: agynio/token-counting#11