### PR TITLE
fix(image): use numeric user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,8 +47,8 @@ COPY --from=build /out/encodings/o200k_base.tiktoken /app/encodings/o200k_base.t
 
 ENV TOKEN_COUNTING_BPE_PATH=/app/encodings/o200k_base.tiktoken
 
-RUN addgroup -S app && adduser -S app -G app
+RUN addgroup -g 10001 -S app && adduser -u 10001 -S app -G app
 
-USER app
+USER 10001
 
 ENTRYPOINT ["/app/token-counting"]

--- a/charts/token-counting/templates/service-base.yaml
+++ b/charts/token-counting/templates/service-base.yaml
@@ -1,8 +1,15 @@
-{{- include "service-base.rbac" . -}}
-{{- include "service-base.serviceAccount" . -}}
-{{- include "service-base.service" . -}}
-{{- include "service-base.deployment" . -}}
-{{- include "service-base.hpa" . -}}
-{{- include "service-base.ingress" . -}}
-{{- include "service-base.pdb" . -}}
-{{- include "service-base.metrics" . -}}
+{{ include "service-base.rbac" . }}
+---
+{{ include "service-base.serviceAccount" . }}
+---
+{{ include "service-base.service" . }}
+---
+{{ include "service-base.deployment" . }}
+---
+{{ include "service-base.hpa" . }}
+---
+{{ include "service-base.ingress" . }}
+---
+{{ include "service-base.pdb" . }}
+---
+{{ include "service-base.metrics" . }}


### PR DESCRIPTION
## Summary
- create the app user with an explicit UID/GID and run the image as numeric UID
- add YAML document separators between service-base includes to fix helm lint

## Testing
- helm dependency build charts/token-counting
- helm lint charts/token-counting
- go vet ./...
- go test ./...
- go build ./...

Refs: agynio/token-counting#11